### PR TITLE
WIP: Format JS/CSS/HTML with Google Style & fix lint issues

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+content/
+docs/
+node_modules/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/app.js
+++ b/app.js
@@ -24,143 +24,165 @@ const git = simpleGit();
  * If the directory exists and is not empty, it assumes the repository is already cloned.
  * @async
  * @function cloneRepo
- * @param {string} repoUrl - The URL of the Git repository to clone.
- * @param {string} localPath - The local filesystem path where the repository should be cloned.
+ * @param {string} repoUrl The URL of the Git repository to clone.
+ * @param {string} localPath The local filesystem path where the repository should be cloned.
  * @returns {Promise<void>} A promise that resolves when the cloning is complete or if the directory already exists and is not empty.
  * @throws {Error} If cloning fails.
  */
 async function cloneRepo(repoUrl, localPath) {
-    try {
-        const CWD = process.cwd();
-        const targetPath = path.resolve(CWD, localPath);
+  try {
+    const CWD = process.cwd();
+    const targetPath = path.resolve(CWD, localPath);
 
-        if (await fs.pathExists(targetPath) && (await fs.readdir(targetPath)).length > 0) {
-            console.log(`Directory ${targetPath} already exists and is not empty. Assuming it's the repo.`);
-            return;
-        }
-
-        console.log(`Cloning ${repoUrl} into ${targetPath}...`);
-        await git.clone(repoUrl, targetPath);
-        console.log("Repository cloned successfully.");
-    } catch (error) {
-        console.error(`Error cloning repository: ${error.message}`);
-        throw error;
+    if (
+      (await fs.pathExists(targetPath)) &&
+      (await fs.readdir(targetPath)).length > 0
+    ) {
+      console.log(
+        `Directory ${targetPath} already exists and is not empty. Assuming it's the repo.`
+      );
+      return;
     }
+
+    console.log(`Cloning ${repoUrl} into ${targetPath}...`);
+    await git.clone(repoUrl, targetPath);
+    console.log('Repository cloned successfully.');
+  } catch (error) {
+    console.error(`Error cloning repository: ${error.message}`);
+    throw error;
+  }
 }
 
 /**
  * Pulls the latest changes from the remote repository for a local Git repository.
  * @async
  * @function pullRepo
- * @param {string} localPath - The local filesystem path of the Git repository.
+ * @param {string} localPath The local filesystem path of the Git repository.
  * @returns {Promise<void>} A promise that resolves when the pull operation is complete.
  * @throws {Error} If the path is not a git repository or if pulling fails.
  */
 async function pullRepo(localPath) {
-    try {
-        const CWD = process.cwd();
-        const targetPath = path.resolve(CWD, localPath);
+  try {
+    const CWD = process.cwd();
+    const targetPath = path.resolve(CWD, localPath);
 
-        if (!await fs.pathExists(path.join(targetPath, '.git'))) {
-            console.error(`Error: ${targetPath} is not a git repository.`);
-            return;
-        }
-
-        console.log(`Pulling latest changes for repository at ${targetPath}...`);
-        await simpleGit(targetPath).pull();
-        console.log("Repository up to date.");
-    } catch (error) {
-        console.error(`Error pulling repository: ${error.message}`);
-        throw error;
+    if (!(await fs.pathExists(path.join(targetPath, '.git')))) {
+      console.error(`Error: ${targetPath} is not a git repository.`);
+      return;
     }
+
+    console.log(`Pulling latest changes for repository at ${targetPath}...`);
+    await simpleGit(targetPath).pull();
+    console.log('Repository up to date.');
+  } catch (error) {
+    console.error(`Error pulling repository: ${error.message}`);
+    throw error;
+  }
 }
 
 /**
  * Recursively lists all Markdown (.md) files in a given directory, excluding the .git directory.
  * @async
  * @function listMarkdownFiles
- * @param {string} basePath - The base path of the directory to scan. Paths returned will be relative to this base path.
+ * @param {string} basePath The base path of the directory to scan. Paths returned will be relative to this base path.
  * @returns {Promise<string[]>} A promise that resolves with an array of relative file paths to the Markdown files found.
  *                               Returns an empty array if the directory does not exist or if an error occurs.
  */
 async function listMarkdownFiles(basePath) {
-    const mdFiles = [];
-    const CWD = process.cwd();
-    const absoluteBasePath = path.resolve(CWD, basePath);
+  const mdFiles = [];
+  const CWD = process.cwd();
+  const absoluteBasePath = path.resolve(CWD, basePath);
 
-    async function findFiles(currentPath) {
-        const entries = await fs.readdir(currentPath, { withFileTypes: true });
-        for (const entry of entries) {
-            const fullEntryPath = path.join(currentPath, entry.name);
-            if (entry.isDirectory()) {
-                if (entry.name === '.git') {
-                    continue;
-                }
-                await findFiles(fullEntryPath);
-            } else if (entry.isFile() && entry.name.endsWith('.md')) {
-                mdFiles.push(path.relative(absoluteBasePath, fullEntryPath));
-            }
+  /**
+   * Helper function to recursively find markdown files.
+   * @async
+   * @param {string} currentPath The current directory path to scan.
+   * @returns {Promise<void>}
+   */
+  async function findFiles(currentPath) {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullEntryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '.git') {
+          continue;
         }
+        await findFiles(fullEntryPath);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        mdFiles.push(path.relative(absoluteBasePath, fullEntryPath));
+      }
     }
+  }
 
-    try {
-        if (!await fs.pathExists(absoluteBasePath)) {
-            console.error(`Error: Directory ${absoluteBasePath} does not exist.`);
-            return [];
-        }
-        await findFiles(absoluteBasePath);
-        return mdFiles;
-    } catch (error) {
-        console.error(`Error listing markdown files: ${error.message}`);
-        return [];
+  try {
+    if (!(await fs.pathExists(absoluteBasePath))) {
+      console.error(`Error: Directory ${absoluteBasePath} does not exist.`);
+      return [];
     }
+    await findFiles(absoluteBasePath);
+    return mdFiles;
+  } catch (error) {
+    console.error(`Error listing markdown files: ${error.message}`);
+    return [];
+  }
 }
-
 
 /**
  * Stages specified files and commits them to the local Git repository.
  * @async
  * @function commitChanges
- * @param {string} localPath - The absolute path to the local repository.
- * @param {string} message - The commit message.
- * @param {string[]} [filesToAdd=[]] - An array of file paths (relative to the repository root) to add to the staging area before committing.
+ * @param {string} localPath The absolute path to the local repository.
+ * @param {string} message The commit message.
+ * @param {string[]} [filesToAdd=[]] An array of file paths (relative to the repository root) to add to the staging area before committing.
  *                                    If empty or not provided, commits currently staged changes.
  * @returns {Promise<void>} A promise that resolves when the changes are committed.
  * @throws {Error} If committing fails (e.g., Git user not configured, no changes to commit).
  */
 async function commitChanges(localPath, message, filesToAdd) {
-    try {
-        console.log(`Attempting to commit changes in ${localPath}...`);
-        const repoGit = simpleGit(localPath);
+  try {
+    console.log(`Attempting to commit changes in ${localPath}...`);
+    const repoGit = simpleGit(localPath);
 
-        if (filesToAdd && filesToAdd.length > 0) {
-            for (const file of filesToAdd) {
-                await repoGit.add(file);
-                console.log(`Added ${file} to staging area.`);
-            }
-        } else {
-            console.log("No specific files provided to add. Committing existing staged changes if any.");
-        }
-
-        const statusAfterAdd = await repoGit.status();
-        if (statusAfterAdd.staged.length === 0) {
-            console.log("No changes were staged for commit. This might happen if the file wasn't modified or saved.");
-        }
-
-        await repoGit.commit(message);
-        console.log(`Changes committed with message: "${message}"`);
-    } catch (error) {
-        console.error(`Error committing changes: ${error.message}`);
-        if (error.message.includes("Please tell me who you are") || error.message.includes("user.name") || error.message.includes("user.email")) {
-            console.error("\nGit user identity (name and email) is not configured.");
-            console.error("Please configure it using the following commands and try again:");
-            console.error("  git config --global user.name \"Your Name\"");
-            console.error("  git config --global user.email \"youremail@example.com\"");
-        } else if (error.message.includes("nothing to commit")) {
-            console.warn("Commit failed: Nothing to commit. Ensure your file was saved and changed, or that there were other staged changes.");
-        }
-        throw error;
+    if (filesToAdd && filesToAdd.length > 0) {
+      for (const file of filesToAdd) {
+        await repoGit.add(file);
+        console.log(`Added ${file} to staging area.`);
+      }
+    } else {
+      console.log(
+        'No specific files provided to add. Committing existing staged changes if any.'
+      );
     }
+
+    const statusAfterAdd = await repoGit.status();
+    if (statusAfterAdd.staged.length === 0) {
+      console.log(
+        "No changes were staged for commit. This might happen if the file wasn't modified or saved."
+      );
+    }
+
+    await repoGit.commit(message);
+    console.log(`Changes committed with message: "${message}"`);
+  } catch (error) {
+    console.error(`Error committing changes: ${error.message}`);
+    if (
+      error.message.includes('Please tell me who you are') ||
+      error.message.includes('user.name') ||
+      error.message.includes('user.email')
+    ) {
+      console.error('\nGit user identity (name and email) is not configured.');
+      console.error(
+        'Please configure it using the following commands and try again:'
+      );
+      console.error('  git config --global user.name "Your Name"');
+      console.error('  git config --global user.email "youremail@example.com"');
+    } else if (error.message.includes('nothing to commit')) {
+      console.warn(
+        'Commit failed: Nothing to commit. Ensure your file was saved and changed, or that there were other staged changes.'
+      );
+    }
+    throw error;
+  }
 }
 
 /**
@@ -168,38 +190,47 @@ async function commitChanges(localPath, message, filesToAdd) {
  * It attempts to push the current branch and set upstream if not already set.
  * @async
  * @function pushChanges
- * @param {string} localPath - The absolute path to the local repository.
+ * @param {string} localPath The absolute path to the local repository.
  * @returns {Promise<void>} A promise that resolves when the changes are pushed successfully.
  * @throws {Error} If pushing fails (e.g., no internet, authentication issues, remote has new changes).
  */
 async function pushChanges(localPath) {
-    try {
-        console.log(`Pushing changes from ${localPath} to remote...`);
-        const repoGit = simpleGit(localPath);
+  try {
+    console.log(`Pushing changes from ${localPath} to remote...`);
+    const repoGit = simpleGit(localPath);
 
-        const status = await repoGit.status();
-        const currentBranch = status.current;
+    const status = await repoGit.status();
+    const currentBranch = status.current;
 
-        if (!currentBranch) {
-            console.error("Could not determine the current branch. Cannot push.");
-            throw new Error("Current branch could not be determined for push operation.");
-        }
-
-        console.log(`Pushing to remote 'origin' branch '${currentBranch}'...`);
-        await repoGit.push('origin', currentBranch, ['--set-upstream']);
-        console.log("Changes pushed successfully.");
-    } catch (error) {
-        console.error(`Error pushing changes: ${error.message}`);
-        console.error("\nPushing failed. Common reasons include:");
-        console.error("  - No internet connection.");
-        console.error("  - Incorrect repository URL or insufficient permissions (authentication failed).");
-        console.error("    (Ensure your PAT or SSH key is correctly set up with GitHub/your Git provider).");
-        console.error("  - Remote repository has new changes you need to pull first (run `git pull` manually or re-run the tool to pull).");
-        console.error("  - The local branch does not have a tracking relationship with a remote branch (the `--set-upstream` flag attempts to fix this for the first push).");
-        throw error;
+    if (!currentBranch) {
+      console.error('Could not determine the current branch. Cannot push.');
+      throw new Error(
+        'Current branch could not be determined for push operation.'
+      );
     }
-}
 
+    console.log(`Pushing to remote 'origin' branch '${currentBranch}'...`);
+    await repoGit.push('origin', currentBranch, ['--set-upstream']);
+    console.log('Changes pushed successfully.');
+  } catch (error) {
+    console.error(`Error pushing changes: ${error.message}`);
+    console.error('\nPushing failed. Common reasons include:');
+    console.error('  - No internet connection.');
+    console.error(
+      '  - Incorrect repository URL or insufficient permissions (authentication failed).'
+    );
+    console.error(
+      '    (Ensure your PAT or SSH key is correctly set up with GitHub/your Git provider).'
+    );
+    console.error(
+      '  - Remote repository has new changes you need to pull first (run `git pull` manually or re-run the tool to pull).'
+    );
+    console.error(
+      '  - The local branch does not have a tracking relationship with a remote branch (the `--set-upstream` flag attempts to fix this for the first push).'
+    );
+    throw error;
+  }
+}
 
 /**
  * Main function to orchestrate the application workflow.
@@ -209,137 +240,168 @@ async function pushChanges(localPath) {
  * @function main
  */
 async function main() {
-    console.log("Welcome to the Markdown Editor GitHub Tool (Node.js)!");
+  console.log('Welcome to the Markdown Editor GitHub Tool (Node.js)!');
 
-    const questions = [
-        {
-            type: 'input',
-            name: 'repoUrl',
-            message: 'Enter the GitHub repository URL:',
-            validate: function (value) {
-                if (value.length && (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('git@'))) {
-                    return true;
-                }
-                return 'Please enter a valid repository URL.';
-            },
-        },
-        {
-            type: 'input',
-            name: 'localPath',
-            message: 'Enter the local directory path for the clone (e.g., ./my-repo):',
-            default: './cloned_repo_nodejs',
-            validate: function (value) {
-                if (value.length) {
-                    return true;
-                }
-                return 'Please enter a local path.';
-            },
-        },
-    ];
-
-    const answers = await inquirer.prompt(questions);
-    const { repoUrl, localPath } = answers;
-    const absoluteLocalPath = path.resolve(process.cwd(), localPath);
-
-
-    try {
-        console.log(`Using repository URL: ${repoUrl}`);
-        console.log(`Using local path: ${absoluteLocalPath}`);
-
-        await fs.ensureDir(absoluteLocalPath);
-        console.log(`Ensured directory exists: ${absoluteLocalPath}`);
-
-        const gitDirExists = await fs.pathExists(path.join(absoluteLocalPath, '.git'));
-
-        if (gitDirExists) {
-            console.log("Repository seems to exist locally. Pulling updates...");
-            await pullRepo(absoluteLocalPath);
-        } else {
-            const filesInDir = await fs.readdir(absoluteLocalPath);
-            if (filesInDir.length > 0) {
-                const { confirmClone } = await inquirer.prompt([{
-                    type: 'confirm',
-                    name: 'confirmClone',
-                    message: `Directory ${absoluteLocalPath} is not empty and not a git repo. Clone into it anyway? (This might overwrite existing files if they conflict with repo files)`,
-                    default: false
-                }]);
-                if (!confirmClone) {
-                    console.log("Cloning aborted by user.");
-                    return;
-                }
-            }
-            console.log("Cloning repository...");
-            await cloneRepo(repoUrl, absoluteLocalPath);
+  const questions = [
+    {
+      type: 'input',
+      name: 'repoUrl',
+      message: 'Enter the GitHub repository URL:',
+      /**
+       * Validates the repository URL.
+       * @param {string} value The input value.
+       * @returns {boolean|string} True if valid, or an error message string.
+       */
+      validate: function(value) {
+        if (
+          value.length &&
+          (value.startsWith('http://') ||
+            value.startsWith('https://') ||
+            value.startsWith('git@'))
+        ) {
+          return true;
         }
+        return 'Please enter a valid repository URL.';
+      },
+    },
+    {
+      type: 'input',
+      name: 'localPath',
+      message:
+        'Enter the local directory path for the clone (e.g., ./my-repo):',
+      default: './cloned_repo_nodejs',
+      /**
+       * Validates the local path.
+       * @param {string} value The input value.
+       * @returns {boolean|string} True if valid, or an error message string.
+       */
+      validate: function(value) {
+        if (value.length) {
+          return true;
+        }
+        return 'Please enter a local path.';
+      },
+    },
+  ];
 
-        const markdownFiles = await listMarkdownFiles(absoluteLocalPath);
-        if (markdownFiles.length > 0) {
-            console.log("\nFound Markdown files:");
-            markdownFiles.forEach((file, index) => {
-                console.log(`  ${index + 1}. ${file}`);
-            });
+  const answers = await inquirer.prompt(questions);
+  const { repoUrl, localPath } = answers;
+  const absoluteLocalPath = path.resolve(process.cwd(), localPath);
 
-            const { selectedFile } = await inquirer.prompt([
-                {
-                    type: 'list',
-                    name: 'selectedFile',
-                    message: 'Select a markdown file to edit:',
-                    choices: markdownFiles,
-                    filter: function (val) {
-                        return val;
-                    }
+  try {
+    console.log(`Using repository URL: ${repoUrl}`);
+    console.log(`Using local path: ${absoluteLocalPath}`);
+
+    await fs.ensureDir(absoluteLocalPath);
+    console.log(`Ensured directory exists: ${absoluteLocalPath}`);
+
+    const gitDirExists = await fs.pathExists(
+      path.join(absoluteLocalPath, '.git')
+    );
+
+    if (gitDirExists) {
+      console.log('Repository seems to exist locally. Pulling updates...');
+      await pullRepo(absoluteLocalPath);
+    } else {
+      const filesInDir = await fs.readdir(absoluteLocalPath);
+      if (filesInDir.length > 0) {
+        const { confirmClone } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'confirmClone',
+            message: `Directory ${absoluteLocalPath} is not empty and not a git repo. Clone into it anyway? (This might overwrite existing files if they conflict with repo files)`,
+            default: false,
+          },
+        ]);
+        if (!confirmClone) {
+          console.log('Cloning aborted by user.');
+          return;
+        }
+      }
+      console.log('Cloning repository...');
+      await cloneRepo(repoUrl, absoluteLocalPath);
+    }
+
+    const markdownFiles = await listMarkdownFiles(absoluteLocalPath);
+    if (markdownFiles.length > 0) {
+      console.log('\nFound Markdown files:');
+      markdownFiles.forEach((file, index) => {
+        console.log(`  ${index + 1}. ${file}`);
+      });
+
+      const { selectedFile } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selectedFile',
+          message: 'Select a markdown file to edit:',
+          choices: markdownFiles,
+          /**
+           * Filters the selected file value.
+           * @param {string} val The input value.
+           * @returns {string} The filtered value.
+           */
+          filter: function(val) {
+            return val;
+          },
+        },
+      ]);
+
+      if (selectedFile) {
+        const fullFilePath = path.join(absoluteLocalPath, selectedFile);
+        console.log(`Opening ${fullFilePath}...`);
+        try {
+          await open(fullFilePath);
+          console.log(
+            `File ${selectedFile} opened. Please edit and save it using your default markdown editor.`
+          );
+
+          const { readyToCommit } = await inquirer.prompt([
+            {
+              type: 'confirm',
+              name: 'readyToCommit',
+              message:
+                'Have you saved your changes and are you ready to commit them?',
+              default: true,
+            },
+          ]);
+
+          if (readyToCommit) {
+            const { commitMessage } = await inquirer.prompt([
+              {
+                type: 'input',
+                name: 'commitMessage',
+                message: 'Enter your commit message:',
+                /**
+                 * Validates the commit message.
+                 * @param {string} value The input value.
+                 * @returns {boolean|string} True if valid, or an error message string.
+                 */
+                validate: function(value) {
+                  if (value.trim().length > 0) {
+                    return true;
+                  }
+                  return 'Please enter a commit message.';
                 },
+              },
             ]);
 
-            if (selectedFile) {
-                const fullFilePath = path.join(absoluteLocalPath, selectedFile);
-                console.log(`Opening ${fullFilePath}...`);
-                try {
-                    await open(fullFilePath);
-                    console.log(`File ${selectedFile} opened. Please edit and save it using your default markdown editor.`);
-
-                    const { readyToCommit } = await inquirer.prompt([
-                        {
-                            type: 'confirm',
-                            name: 'readyToCommit',
-                            message: 'Have you saved your changes and are you ready to commit them?',
-                            default: true,
-                        }
-                    ]);
-
-                    if (readyToCommit) {
-                        const { commitMessage } = await inquirer.prompt([
-                            {
-                                type: 'input',
-                                name: 'commitMessage',
-                                message: 'Enter your commit message:',
-                                validate: function(value) {
-                                    if (value.trim().length > 0) {
-                                        return true;
-                                    }
-                                    return 'Please enter a commit message.';
-                                }
-                            }
-                        ]);
-
-                        await commitChanges(absoluteLocalPath, commitMessage, [selectedFile]);
-                        await pushChanges(absoluteLocalPath);
-                    } else {
-                        console.log("Commit and push aborted by user.");
-                    }
-
-                } catch (openError) {
-                    console.error(`Error opening file ${selectedFile}:`, openError);
-                }
-            }
-
-        } else {
-            console.log("No Markdown files found in the repository.");
+            await commitChanges(absoluteLocalPath, commitMessage, [
+              selectedFile,
+            ]);
+            await pushChanges(absoluteLocalPath);
+          } else {
+            console.log('Commit and push aborted by user.');
+          }
+        } catch (openError) {
+          console.error(`Error opening file ${selectedFile}:`, openError);
         }
-
-    } catch (error) {
-        console.error("An error occurred in the main workflow:", error.message);
+      }
+    } else {
+      console.log('No Markdown files found in the repository.');
     }
+  } catch (error) {
+    console.error('An error occurred in the main workflow:', error.message);
+  }
 }
 
 main().catch(console.error);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,155 @@
+// eslint.config.js
+import globals from 'globals';
+import js from '@eslint/js';
+import { FlatCompat } from '@eslint/eslintrc';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import jsdocPlugin from 'eslint-plugin-jsdoc';
+import configGoogle from 'eslint-config-google';
+
+// Mimic CommonJS variables for FlatCompat
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  resolvePluginsRelativeTo: __dirname,
+});
+
+export default [
+  {
+    ignores: [
+      'node_modules/',
+      'docs/',
+      'content/',
+      '.prettierrc.json',
+      'jsdoc.json',
+      '.git/',
+      '.vscode/',
+      '*.md',
+      'eslint.config.js',
+      'package-lock.json',
+      'package.json',
+    ],
+  },
+
+  js.configs.recommended,
+  ...compat.config(configGoogle),
+
+  {
+    files: ['**/*.js'],
+    plugins: {
+      jsdoc: jsdocPlugin,
+    },
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    rules: {
+      indent: 'off',
+      'max-len': [
+        'warn',
+        {
+          code: 80,
+          ignoreComments: true,
+          ignoreUrls: true,
+          ignoreStrings: true,
+          ignoreTemplateLiterals: true,
+          ignoreRegExpLiterals: true,
+          ignorePattern: '^goog\\.(module|require)',
+        },
+      ],
+      'no-console': 'off',
+      'require-jsdoc': 'off', // Turn off Google's version
+      'valid-jsdoc': 'off', // Turn off Google's version
+
+      'jsdoc/require-jsdoc': [
+        'warn',
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: true,
+          },
+          publicOnly: false,
+          contexts: [
+            'MethodDefinition[kind="method"]',
+            'FunctionDeclaration',
+            'ClassDeclaration',
+            'ExportNamedDeclaration[declaration.type="FunctionDeclaration"]',
+            'ExportNamedDeclaration[declaration.type="ClassDeclaration"]',
+          ],
+          enableFixer: false,
+        },
+      ],
+      'jsdoc/check-types': 'warn',
+      'jsdoc/check-tag-names': [
+        'warn',
+        {
+          definedTags: ['final', 'abstract', 'virtual', 'override', 'package'],
+        },
+      ],
+      'jsdoc/check-param-names': [
+        'warn',
+        { checkDestructured: false, enableFixer: false },
+      ],
+      'jsdoc/require-param': [
+        'warn',
+        {
+          checkDestructured: false,
+          checkRestProperty: true,
+          enableFixer: false,
+        },
+      ],
+      'jsdoc/require-param-name': 'warn',
+      'jsdoc/require-param-type': 'warn',
+      'jsdoc/require-param-description': 'warn',
+      'jsdoc/require-returns': [
+        'warn',
+        { checkGetters: false, enableFixer: false },
+      ],
+      'jsdoc/require-returns-type': 'warn',
+      'jsdoc/require-returns-description': 'warn',
+      'jsdoc/no-undefined-types': ['warn', { disableReporting: true }],
+      'jsdoc/require-hyphen-before-param-description': ['warn', 'never'],
+      'jsdoc/tag-lines': ['warn', 'never', { applyToEndTag: false }],
+      'jsdoc/check-alignment': 'warn',
+      // 'jsdoc/check-indentation': 'warn', // Often conflicts with Prettier, keep commented
+
+      semi: ['error', 'always'],
+      quotes: [
+        'warn',
+        'single',
+        { avoidEscape: true, allowTemplateLiterals: true },
+      ],
+      'comma-dangle': 'off', // Let Prettier handle this
+      'object-curly-spacing': ['warn', 'always'],
+      'array-bracket-spacing': ['warn', 'never'],
+      'space-infix-ops': 'warn',
+      curly: ['warn', 'all'],
+      'no-var': 'error',
+      'prefer-const': ['warn', { destructuring: 'all' }],
+      eqeqeq: ['warn', 'always', { null: 'ignore' }],
+      'one-var': ['warn', 'never'],
+      'padded-blocks': ['warn', 'never'],
+      'space-before-blocks': 'warn',
+      'space-before-function-paren': [
+        'warn',
+        {
+          anonymous: 'always',
+          named: 'never',
+          asyncArrow: 'always',
+        },
+      ],
+      'keyword-spacing': ['warn', { before: true, after: true }],
+      'space-in-parens': ['warn', 'never'],
+      'no-trailing-spaces': 'warn',
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,14 @@
         "simple-git": "^3.22.0"
       },
       "devDependencies": {
-        "jsdoc": "^4.0.4"
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "^9.30.0",
+        "eslint": "^9.30.0",
+        "eslint-config-google": "^0.14.0",
+        "eslint-plugin-jsdoc": "^51.2.3",
+        "globals": "^16.2.0",
+        "jsdoc": "^4.0.4",
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -71,6 +78,306 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.52.0.tgz",
+      "integrity": "sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.34.1",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
+      "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@inquirer/figures": {
@@ -133,6 +440,20 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -158,6 +479,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -169,6 +504,46 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -208,6 +583,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -384,6 +769,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/catharsis": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
@@ -479,6 +874,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -521,6 +926,21 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -529,6 +949,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.2.1",
@@ -710,6 +1137,275 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
+      "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.30.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-google": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "51.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-51.2.3.tgz",
+      "integrity": "sha512-pagzxFubOih+O6XSB1D8BkDkJjF4G4/v8s9pRg4FkXQJLu0e3QJg621ayhmnhyc5mNBpp3cYCNiUyeLQs7oz7w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.52.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.4.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -784,6 +1480,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -831,6 +1561,44 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -908,6 +1676,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -1009,6 +1803,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1062,6 +1893,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1069,6 +1910,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -1125,6 +1979,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jake": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
@@ -1141,6 +2002,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/js2xmlparser": {
@@ -1183,6 +2057,37 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1195,6 +2100,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/klaw": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
@@ -1203,6 +2118,20 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/linkify-it": {
@@ -1215,10 +2144,33 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1410,6 +2362,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1476,6 +2435,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -1508,6 +2485,68 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1517,11 +2556,57 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1534,6 +2619,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -1609,6 +2704,16 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -1678,6 +2783,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
@@ -1737,6 +2855,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1854,6 +2995,31 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1950,6 +3116,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -2007,6 +3186,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2040,6 +3229,32 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -2060,6 +3275,19 @@
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "get:content": "node app.js",
     "start": "node server.js",
     "git:get": "git fetch --all;git reset --hard origin/main;",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint . --ext .js",
+    "format": "prettier --write \"./*.js\" \"public/**/*.{js,css}\" \"services/**/*.js\" \"routes/**/*.js\" \"views/**/*.ejs\" --ignore-path .prettierignore",
+    "format:check": "prettier --check \"./*.js\" \"public/**/*.{js,css}\" \"services/**/*.js\" \"routes/**/*.js\" \"views/**/*.ejs\" --ignore-path .prettierignore"
   },
   "keywords": [
     "git",
@@ -19,20 +22,27 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "ejs": "^3.1.9",
+    "express": "^4.18.2",
+    "express-ejs-layouts": "^2.5.1",
     "fs-extra": "^11.2.0",
     "inquirer": "^9.2.20",
-    "open": "^10.1.0",
-    "simple-git": "^3.22.0",
-    "express": "^4.18.2",
-    "ejs": "^3.1.9",
-    "express-ejs-layouts": "^2.5.1",
+    "lunr": "^2.3.9",
     "marked": "^4.0.10",
-    "lunr": "^2.3.9"
+    "open": "^10.1.0",
+    "simple-git": "^3.22.0"
   },
   "repository": {},
   "bugs": {},
   "homepage": "",
   "devDependencies": {
-    "jsdoc": "^4.0.4"
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "^9.30.0",
+    "eslint": "^9.30.0",
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-jsdoc": "^51.2.3",
+    "globals": "^16.2.0",
+    "jsdoc": "^4.0.4",
+    "prettier": "^3.6.2"
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,114 +1,116 @@
 html {
-    height: 100%;
+  height: 100%;
 }
 
 body {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    margin: 0;
-    padding-bottom: 60px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-    font-size: 16px;
-    line-height: 1.5;
-    color: #333;
-    background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  margin: 0;
+  padding-bottom: 60px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #333;
+  background-color: #fff;
 }
 
 .container-fluid.flex-grow-1 {
-    flex-grow: 1;
-    display: flex;
+  flex-grow: 1;
+  display: flex;
 }
 
 .row.flex-grow-1 {
-    flex-grow: 1;
+  flex-grow: 1;
 }
 
 .navigation-pane {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 .navigation-pane .position-sticky {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 .navigation-pane .nav {
-    flex-grow: 1;
-    overflow-y: auto;
+  flex-grow: 1;
+  overflow-y: auto;
 }
 
 .search-bar {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .search-container {
-    min-width: 250px;
+  min-width: 250px;
 }
 
 #searchResults {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    max-height: 300px;
-    overflow-y: auto;
-    margin-top: .125rem;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  max-height: 300px;
+  overflow-y: auto;
+  margin-top: 0.125rem;
 }
 
 #searchResults ul {
-    list-style-type: none;
-    padding-left: 0;
-    margin: 0;
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
 }
 
 #searchResults li a {
-    display: block;
-    padding: 0.5rem 1rem;
-    color: #212529;
-    text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  display: block;
+  padding: 0.5rem 1rem;
+  color: #212529;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #searchResults li a:hover {
-    background-color: #e9ecef;
-    color: #000;
+  background-color: #e9ecef;
+  color: #000;
 }
 
 #searchResults.show {
-    display: block;
+  display: block;
 }
 
 .navigation-pane .nav-icon {
-    margin-right: 8px;
-    vertical-align: text-bottom;
+  margin-right: 8px;
+  vertical-align: text-bottom;
 }
 
 .navigation-pane .nav-icon > .bi {
-    font-size: 1em;
+  font-size: 1em;
 }
 
 .navigation-pane li strong {
-    font-weight: 500;
-    color: #24292e;
-    cursor: default;
-    font-size: 0.95em;
-    line-height: 1.5;
+  font-weight: 500;
+  color: #24292e;
+  cursor: default;
+  font-size: 0.95em;
+  line-height: 1.5;
 }
 .navigation-pane .nav-link {
-    line-height: 1.5;
+  line-height: 1.5;
 }
 
 .content-pane {
-    overflow-y: auto;
-    box-sizing: border-box;
+  overflow-y: auto;
+  box-sizing: border-box;
 }
 
 .markdown-body {
-    line-height: 1.7;
-    color: #24292e;
-    width: 100%;
+  line-height: 1.7;
+  color: #24292e;
+  width: 100%;
 }
 
 .markdown-body h1,
@@ -117,123 +119,136 @@ body {
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-    margin-top: 1.5em;
-    margin-bottom: 0.8em;
-    font-weight: 600;
-    line-height: 1.25;
-    color: #111;
+  margin-top: 1.5em;
+  margin-bottom: 0.8em;
+  font-weight: 600;
+  line-height: 1.25;
+  color: #111;
 }
 
 .markdown-body h1 {
-    font-size: 2.25em;
-    border-bottom: 1px solid #eaecef;
-    padding-bottom: 0.3em;
+  font-size: 2.25em;
+  border-bottom: 1px solid #eaecef;
+  padding-bottom: 0.3em;
 }
 
 .markdown-body h2 {
-    font-size: 1.75em;
-    border-bottom: 1px solid #eaecef;
-    padding-bottom: 0.3em;
+  font-size: 1.75em;
+  border-bottom: 1px solid #eaecef;
+  padding-bottom: 0.3em;
 }
 
-.markdown-body h3 { font-size: 1.4em; }
-.markdown-body h4 { font-size: 1.15em; }
-.markdown-body h5 { font-size: 1em; font-weight: 500; }
-.markdown-body h6 { font-size: 0.9em; color: #586069; font-weight: 500; }
+.markdown-body h3 {
+  font-size: 1.4em;
+}
+.markdown-body h4 {
+  font-size: 1.15em;
+}
+.markdown-body h5 {
+  font-size: 1em;
+  font-weight: 500;
+}
+.markdown-body h6 {
+  font-size: 0.9em;
+  color: #586069;
+  font-weight: 500;
+}
 
 .markdown-body p {
-    margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 
 .markdown-body ul,
 .markdown-body ol {
-    padding-left: 2em;
-    margin-bottom: 1em;
+  padding-left: 2em;
+  margin-bottom: 1em;
 }
-.markdown-body ul li, .markdown-body ol li {
-    margin-bottom: 0.25em;
+.markdown-body ul li,
+.markdown-body ol li {
+  margin-bottom: 0.25em;
 }
 
 .markdown-body li > p {
-    margin-bottom: 0.25em;
+  margin-bottom: 0.25em;
 }
 
 .markdown-body blockquote {
-    margin: 0 0 1em 0;
-    padding: 0.5em 1em;
-    color: #586069;
-    border-left: 0.25em solid #dfe2e5;
-    background-color: #f9f9f9;
+  margin: 0 0 1em 0;
+  padding: 0.5em 1em;
+  color: #586069;
+  border-left: 0.25em solid #dfe2e5;
+  background-color: #f9f9f9;
 }
 
 .markdown-body pre {
-    background-color: #f6f8fa;
-    padding: 16px;
-    overflow: auto;
-    font-size: 0.9em;
-    line-height: 1.45;
-    border-radius: 6px;
-    margin-bottom: 1em;
-    border: 1px solid #e1e4e8;
+  background-color: #f6f8fa;
+  padding: 16px;
+  overflow: auto;
+  font-size: 0.9em;
+  line-height: 1.45;
+  border-radius: 6px;
+  margin-bottom: 1em;
+  border: 1px solid #e1e4e8;
 }
 
 .markdown-body code {
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    font-size: 0.875em;
-    padding: 0.2em 0.4em;
-    margin: 0 2px;
-    background-color: rgba(27,31,35,0.07);
-    border-radius: 3px;
+  font-family:
+    'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 0.875em;
+  padding: 0.2em 0.4em;
+  margin: 0 2px;
+  background-color: rgba(27, 31, 35, 0.07);
+  border-radius: 3px;
 }
 
 .markdown-body pre code {
-    font-size: 100%;
-    padding: 0;
-    margin: 0;
-    background-color: transparent;
-    border: 0;
-    color: inherit;
+  font-size: 100%;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border: 0;
+  color: inherit;
 }
 
 .markdown-body table {
-    border-collapse: collapse;
-    margin-bottom: 1em;
-    display: block;
-    width: 100%;
-    overflow: auto;
-    border-spacing: 0;
+  border-collapse: collapse;
+  margin-bottom: 1em;
+  display: block;
+  width: 100%;
+  overflow: auto;
+  border-spacing: 0;
 }
 
 .markdown-body th,
 .markdown-body td {
-    border: 1px solid #dfe2e5;
-    padding: 8px 13px;
+  border: 1px solid #dfe2e5;
+  padding: 8px 13px;
 }
 
 .markdown-body th {
-    font-weight: 600;
-    background-color: #f6f8fa;
+  font-weight: 600;
+  background-color: #f6f8fa;
 }
 .markdown-body tr:nth-child(2n) {
-    background-color: #fcfcfc;
+  background-color: #fcfcfc;
 }
 
 .markdown-body img {
-    max-width: 100%;
-    height: auto;
-    box-sizing: content-box;
-    background-color: #fff;
-    border: 1px solid #e1e4e8;
-    border-radius: 4px;
-    margin: 10px 0;
+  max-width: 100%;
+  height: auto;
+  box-sizing: content-box;
+  background-color: #fff;
+  border: 1px solid #e1e4e8;
+  border-radius: 4px;
+  margin: 10px 0;
 }
 
 .markdown-body hr {
-    height: 4px;
-    padding: 0;
-    margin: 24px 0;
-    background-color: #e1e4e8;
-    border: 0;
+  height: 4px;
+  padding: 0;
+  margin: 24px 0;
+  background-color: #e1e4e8;
+  border: 0;
 }
 
 .sr-only {
@@ -249,41 +264,47 @@ body {
 }
 
 @media (max-width: 768px) {
-    .container {
-        flex-direction: column;
-    }
+  .container {
+    flex-direction: column;
+  }
 
-    .navigation-pane {
-        width: 100%;
-        height: auto;
-        max-height: 40vh;
-        border-right: none;
-        border-bottom: 1px solid #e0e0e0;
-    }
-    .search-bar {
-        position: static;
-        padding-top: 0;
-    }
+  .navigation-pane {
+    width: 100%;
+    height: auto;
+    max-height: 40vh;
+    border-right: none;
+    border-bottom: 1px solid #e0e0e0;
+  }
+  .search-bar {
+    position: static;
+    padding-top: 0;
+  }
 
-    .content-pane {
-        width: 100%;
-        padding: 20px;
-    }
+  .content-pane {
+    width: 100%;
+    padding: 20px;
+  }
 
-    .markdown-body {
-        padding: 0 10px;
-    }
+  .markdown-body {
+    padding: 0 10px;
+  }
 }
 
 @media (max-width: 480px) {
-    .content-pane {
-        padding: 15px;
-    }
-    .markdown-body h1 { font-size: 1.8em; }
-    .markdown-body h2 { font-size: 1.4em; }
-    .markdown-body h3 { font-size: 1.2em; }
+  .content-pane {
+    padding: 15px;
+  }
+  .markdown-body h1 {
+    font-size: 1.8em;
+  }
+  .markdown-body h2 {
+    font-size: 1.4em;
+  }
+  .markdown-body h3 {
+    font-size: 1.2em;
+  }
 }
 
 .footer {
-    font-size: 0.9em;
+  font-size: 0.9em;
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,113 +5,124 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-    /**
-     * @type {HTMLInputElement|null}
-     */
-    const searchInput = document.getElementById('searchInput');
-    /**
-     * @type {HTMLElement|null}
-     */
-    const searchResultsContainer = document.getElementById('searchResults');
+  /**
+   * @type {HTMLInputElement|null}
+   */
+  const searchInput = document.getElementById('searchInput');
+  /**
+   * @type {HTMLElement|null}
+   */
+  const searchResultsContainer = document.getElementById('searchResults');
 
-    if (searchInput && searchResultsContainer) {
-        searchInput.addEventListener('input', async (e) => {
-            const query = e.target.value.trim();
-            searchResultsContainer.innerHTML = ''; // Clear previous results
+  if (searchInput && searchResultsContainer) {
+    searchInput.addEventListener('input', async (e) => {
+      const query = e.target.value.trim();
+      searchResultsContainer.innerHTML = ''; // Clear previous results
 
-            if (query.length < 2) { // Don't search for very short strings
-                searchResultsContainer.classList.remove('show'); // Hide if query is too short
-                return;
-            }
+      if (query.length < 2) {
+        // Don't search for very short strings
+        searchResultsContainer.classList.remove('show'); // Hide if query is too short
+        return;
+      }
 
-            try {
-                const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
-                if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(errorData.error || 'Search request failed');
-                }
-                const results = await response.json(); // Expects an array of { path, name, score }
-
-                if (results.length > 0) {
-                    const ul = document.createElement('ul');
-                    results.forEach(result => {
-                        const li = document.createElement('li');
-                        const link = document.createElement('a');
-                        link.classList.add('dropdown-item'); // Use Bootstrap's dropdown item class for styling consistency
-                        link.href = `/view/${result.path.replace(/\\/g, '/')}`;
-                        link.textContent = result.name || result.path.split('/').pop().replace('.md', ''); // Improved fallback for name
-                        li.appendChild(link);
-                        ul.appendChild(li);
-                    });
-                    searchResultsContainer.appendChild(ul);
-                    searchResultsContainer.classList.add('show'); // Show dropdown
-                } else {
-                    searchResultsContainer.textContent = 'No results found.'; // Consider styling this message or putting it in a list item
-                    searchResultsContainer.classList.add('show'); // Show "No results found"
-                }
-            } catch (error) {
-                console.error('Search error:', error);
-                const li = document.createElement('li');
-                li.classList.add('dropdown-item');
-                li.textContent = `Error: ${error.message || 'Search failed.'}`;
-                const ul = document.createElement('ul');
-                ul.appendChild(li);
-                searchResultsContainer.innerHTML = ''; // Clear previous before adding error
-                searchResultsContainer.appendChild(ul);
-                searchResultsContainer.classList.add('show'); // Show error in dropdown
-            }
-        });
-
-        // Hide dropdown when clicking outside
-        document.addEventListener('click', (event) => {
-            const isClickInsideSearchContainer = searchInput.contains(event.target) || searchResultsContainer.contains(event.target);
-            if (!isClickInsideSearchContainer) {
-                searchResultsContainer.classList.remove('show');
-            }
-        });
-
-        searchInput.addEventListener('focus', () => {
-            if (searchInput.value.trim().length >= 2 && searchResultsContainer.children.length > 0) {
-                searchResultsContainer.classList.add('show');
-            }
-        });
-
-        // Clear and hide if input is manually cleared by backspacing
-        searchInput.addEventListener('keyup', (e) => {
-            if (e.target.value.trim().length < 2) {
-                searchResultsContainer.innerHTML = '';
-                searchResultsContainer.classList.remove('show');
-            }
-        });
-    }
-
-    // Collapsible navigation folder icons
-    const folderToggles = document.querySelectorAll('.navigation-pane .folder-toggle');
-    folderToggles.forEach(toggle => {
-        const targetId = toggle.getAttribute('href'); // or getAttribute('data-bs-target')
-        if (targetId) {
-            const collapseElement = document.querySelector(targetId);
-            if (collapseElement) {
-                // Event listener for when collapse is shown
-                collapseElement.addEventListener('show.bs.collapse', () => {
-                    const icon = toggle.querySelector('.nav-icon > .bi');
-                    if (icon) {
-                        icon.classList.remove('bi-folder');
-                        icon.classList.add('bi-folder2-open');
-                    }
-                });
-
-                // Event listener for when collapse is hidden
-                collapseElement.addEventListener('hide.bs.collapse', () => {
-                    const icon = toggle.querySelector('.nav-icon > .bi');
-                    if (icon) {
-                        icon.classList.remove('bi-folder2-open');
-                        icon.classList.add('bi-folder');
-                    }
-                });
-            }
+      try {
+        const response = await fetch(
+          `/api/search?q=${encodeURIComponent(query)}`
+        );
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || 'Search request failed');
         }
+        const results = await response.json(); // Expects an array of { path, name, score }
+
+        if (results.length > 0) {
+          const ul = document.createElement('ul');
+          results.forEach((result) => {
+            const li = document.createElement('li');
+            const link = document.createElement('a');
+            link.classList.add('dropdown-item'); // Use Bootstrap's dropdown item class for styling consistency
+            link.href = `/view/${result.path.replace(/\\/g, '/')}`;
+            link.textContent =
+              result.name || result.path.split('/').pop().replace('.md', ''); // Improved fallback for name
+            li.appendChild(link);
+            ul.appendChild(li);
+          });
+          searchResultsContainer.appendChild(ul);
+          searchResultsContainer.classList.add('show'); // Show dropdown
+        } else {
+          searchResultsContainer.textContent = 'No results found.'; // Consider styling this message or putting it in a list item
+          searchResultsContainer.classList.add('show'); // Show "No results found"
+        }
+      } catch (error) {
+        console.error('Search error:', error);
+        const li = document.createElement('li');
+        li.classList.add('dropdown-item');
+        li.textContent = `Error: ${error.message || 'Search failed.'}`;
+        const ul = document.createElement('ul');
+        ul.appendChild(li);
+        searchResultsContainer.innerHTML = ''; // Clear previous before adding error
+        searchResultsContainer.appendChild(ul);
+        searchResultsContainer.classList.add('show'); // Show error in dropdown
+      }
     });
 
-    console.log('Main JavaScript loaded and search initialized.');
+    // Hide dropdown when clicking outside
+    document.addEventListener('click', (event) => {
+      const isClickInsideSearchContainer =
+        searchInput.contains(event.target) ||
+        searchResultsContainer.contains(event.target);
+      if (!isClickInsideSearchContainer) {
+        searchResultsContainer.classList.remove('show');
+      }
+    });
+
+    searchInput.addEventListener('focus', () => {
+      if (
+        searchInput.value.trim().length >= 2 &&
+        searchResultsContainer.children.length > 0
+      ) {
+        searchResultsContainer.classList.add('show');
+      }
+    });
+
+    // Clear and hide if input is manually cleared by backspacing
+    searchInput.addEventListener('keyup', (e) => {
+      if (e.target.value.trim().length < 2) {
+        searchResultsContainer.innerHTML = '';
+        searchResultsContainer.classList.remove('show');
+      }
+    });
+  }
+
+  // Collapsible navigation folder icons
+  const folderToggles = document.querySelectorAll(
+    '.navigation-pane .folder-toggle'
+  );
+  folderToggles.forEach((toggle) => {
+    const targetId = toggle.getAttribute('href'); // or getAttribute('data-bs-target')
+    if (targetId) {
+      const collapseElement = document.querySelector(targetId);
+      if (collapseElement) {
+        // Event listener for when collapse is shown
+        collapseElement.addEventListener('show.bs.collapse', () => {
+          const icon = toggle.querySelector('.nav-icon > .bi');
+          if (icon) {
+            icon.classList.remove('bi-folder');
+            icon.classList.add('bi-folder2-open');
+          }
+        });
+
+        // Event listener for when collapse is hidden
+        collapseElement.addEventListener('hide.bs.collapse', () => {
+          const icon = toggle.querySelector('.nav-icon > .bi');
+          if (icon) {
+            icon.classList.remove('bi-folder2-open');
+            icon.classList.add('bi-folder');
+          }
+        });
+      }
+    }
+  });
+
+  console.log('Main JavaScript loaded and search initialized.');
 });

--- a/routes/view.js
+++ b/routes/view.js
@@ -22,58 +22,61 @@ const contentBaseDir = path.join(__dirname, '..', 'content');
  * It captures the file path from the URL, reads the Markdown file,
  * converts it to HTML using 'marked', and then renders it using the 'document' view.
  * Includes basic security to prevent path traversal.
- *
  * @name GET/*
  * @function
  * @memberof module:routes/view
- * @param {express.Request} req - Express request object. The file path is extracted from `req.params[0]`.
- * @param {express.Response} res - Express response object.
- * @param {express.NextFunction} next - Express next middleware function.
+ * @param {express.Request} req Express request object. The file path is extracted from `req.params[0]`.
+ * @param {express.Response} res Express response object.
+ * @param {express.NextFunction} next Express next middleware function.
  * @returns {void}
  */
+// eslint-disable-next-line new-cap
 router.get('/*', async (req, res, next) => {
-    const filePathParam = req.params[0];
+  const filePathParam = req.params[0];
 
-    if (!filePathParam) {
-        return res.status(400).send('No file path specified.');
+  if (!filePathParam) {
+    return res.status(400).send('No file path specified.');
+  }
+
+  // Basic security: prevent path traversal
+  // Normalize the path and ensure it's still within the contentBaseDir
+  const requestedFullPath = path.join(contentBaseDir, filePathParam);
+
+  const resolvedPath = path.resolve(requestedFullPath);
+  const resolvedContentBase = path.resolve(contentBaseDir);
+  if (!resolvedPath.startsWith(resolvedContentBase)) {
+    return res.status(403).send('Access denied: Invalid path.');
+  }
+
+  if (path.extname(filePathParam).toLowerCase() !== '.md') {
+    return res
+      .status(400)
+      .send('Invalid file type. Only .md files can be viewed.');
+  }
+
+  try {
+    const markdownContent = await fs.readFile(requestedFullPath, 'utf-8');
+    const htmlContent = marked.parse(markdownContent);
+
+    res.render('document', {
+      title: path.basename(filePathParam, '.md'),
+      documentHtml: htmlContent,
+    });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.status(404);
+      res.render('404', {
+        title: 'Not Found',
+        filePath: filePathParam,
+      });
+    } else {
+      console.error(
+        `Error reading or parsing markdown file ${filePathParam}:`,
+        error
+      );
+      next(error);
     }
-
-    // Basic security: prevent path traversal
-    // Normalize the path and ensure it's still within the contentBaseDir
-    const requestedFullPath = path.join(contentBaseDir, filePathParam);
-
-    const resolvedPath = path.resolve(requestedFullPath);
-    const resolvedContentBase = path.resolve(contentBaseDir);
-    if (!resolvedPath.startsWith(resolvedContentBase)) {
-        return res.status(403).send('Access denied: Invalid path.');
-    }
-
-    if (path.extname(filePathParam).toLowerCase() !== '.md') {
-        return res.status(400).send('Invalid file type. Only .md files can be viewed.');
-    }
-
-
-    try {
-        const markdownContent = await fs.readFile(requestedFullPath, 'utf-8');
-        const htmlContent = marked.parse(markdownContent);
-
-        res.render('document', {
-            title: path.basename(filePathParam, '.md'),
-            documentHtml: htmlContent,
-        });
-    } catch (error) {
-        if (error.code === 'ENOENT') {
-            res.status(404);
-            res.render('404', {
-                title: 'Not Found',
-                filePath: filePathParam
-            });
-
-        } else {
-            console.error(`Error reading or parsing markdown file ${filePathParam}:`, error);
-            next(error);
-        }
-    }
+  }
 });
 
 /**

--- a/server.js
+++ b/server.js
@@ -27,36 +27,39 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.locals.indexBuilt = false;
 
 app.use(async (req, res, next) => {
-    try {
-        if (!app.locals.directoryTree) {
-            console.log('Fetching directory tree for the first time...');
-            const tree = await getDirectoryTree(contentDir, contentDir);
-            app.locals.directoryTree = tree;
-            console.log('Directory tree fetched.');
-        }
-        res.locals.directoryTree = app.locals.directoryTree;
-
-        if (!app.locals.indexBuilt) {
-            console.log('Building search index for the first time...');
-            await buildIndex(app.locals.directoryTree);
-            app.locals.indexBuilt = true;
-            console.log('Search index built.');
-        }
-        next();
-    } catch (error) {
-        console.error('Error in initial setup (directory tree/search index):', error);
-        next(error);
+  try {
+    if (!app.locals.directoryTree) {
+      console.log('Fetching directory tree for the first time...');
+      const tree = await getDirectoryTree(contentDir, contentDir);
+      app.locals.directoryTree = tree;
+      console.log('Directory tree fetched.');
     }
+    res.locals.directoryTree = app.locals.directoryTree;
+
+    if (!app.locals.indexBuilt) {
+      console.log('Building search index for the first time...');
+      await buildIndex(app.locals.directoryTree);
+      app.locals.indexBuilt = true;
+      console.log('Search index built.');
+    }
+    next();
+  } catch (error) {
+    console.error(
+      'Error in initial setup (directory tree/search index):',
+      error
+    );
+    next(error);
+  }
 });
 
 // API Search Route
 app.get('/api/search', (req, res) => {
-    const query = req.query.q;
-    if (!query) {
-        return res.status(400).json({ error: 'Search query (q) is required.' });
-    }
-    const results = search(query);
-    res.json(results);
+  const query = req.query.q;
+  if (!query) {
+    return res.status(400).json({ error: 'Search query (q) is required.' });
+  }
+  const results = search(query);
+  res.json(results);
 });
 
 // View Routes
@@ -64,20 +67,20 @@ app.use('/view', viewRoutes);
 
 // Home page route
 app.get('/', (req, res) => {
-    res.render('index', { title: 'Home' });
+  res.render('index', { title: 'Home' });
 });
 
 // 404 Handler
 app.use((req, res, next) => {
-    res.status(404).render('404', { title: 'Not Found', filePath: req.path });
+  res.status(404).render('404', { title: 'Not Found', filePath: req.path });
 });
 
 // Error handler
 app.use((err, req, res, next) => {
-    console.error(err.stack);
-    res.status(500).send('Something broke!');
+  console.error(err.stack);
+  res.status(500).send('Something broke!');
 });
 
 app.listen(port, () => {
-    console.log(`Server listening at http://localhost:${port}`);
+  console.log(`Server listening at http://localhost:${port}`);
 });

--- a/services/fileService.js
+++ b/services/fileService.js
@@ -20,91 +20,94 @@ import path from 'path';
  * It lists all files and subdirectories, focusing on Markdown files.
  * Hidden files (starting with '.') are ignored.
  * Children are sorted with folders first, then files, both alphabetically.
- *
  * @async
  * @function getDirectoryTree
- * @param {string} dirPath - The path to the directory to scan.
- * @param {string} contentBaseDir - The base directory for content, used to calculate relative paths.
+ * @param {string} dirPath The path to the directory to scan.
+ * @param {string} contentBaseDir The base directory for content, used to calculate relative paths.
  * @returns {Promise<DirectoryTreeNode>} A promise that resolves to an object representing the directory tree.
  * @throws {Error} If the path is not a directory or if other file system errors occur (excluding ENOENT on initial dirPath scan).
  */
 async function getDirectoryTree(dirPath, contentBaseDir) {
-    let stats;
-    try {
-        stats = await fs.stat(dirPath);
-    } catch (error) {
-        // If path does not exist or is not accessible
-        if (error.code === 'ENOENT') {
-            console.warn(`Directory not found: ${dirPath}. Returning empty for this path.`);
-            // Return a structure indicating it's a folder but with no children,
-            // or handle as an error depending on desired behavior.
-            // For now, let's assume it might be an empty content dir, so create a base tree.
-            return {
-                name: path.basename(dirPath),
-                path: dirPath,
-                type: 'folder',
-                children: []
-            };
-        }
-        throw error; // Re-throw other errors
-    }
-
-    if (!stats.isDirectory()) {
-        throw new Error(`Path is not a directory: ${dirPath}`);
-    }
-
-    const items = await fs.readdir(dirPath);
-    const tree = {
+  let stats;
+  try {
+    stats = await fs.stat(dirPath);
+  } catch (error) {
+    // If path does not exist or is not accessible
+    if (error.code === 'ENOENT') {
+      console.warn(
+        `Directory not found: ${dirPath}. Returning empty for this path.`
+      );
+      // Return a structure indicating it's a folder but with no children,
+      // or handle as an error depending on desired behavior.
+      // For now, let's assume it might be an empty content dir, so create a base tree.
+      return {
         name: path.basename(dirPath),
         path: dirPath,
         type: 'folder',
-        children: []
-    };
-
-    for (const item of items) {
-        // Ignore .gitkeep or other hidden files if necessary
-        if (item.startsWith('.')) {
-            continue;
-        }
-        const itemPath = path.join(dirPath, item);
-        let itemStats;
-        try {
-            itemStats = await fs.stat(itemPath);
-        } catch (error) {
-            if (error.code === 'ENOENT') {
-                console.warn(`File/directory not found during scan: ${itemPath}. Skipping.`);
-                continue; // Skip this item if it disappeared during scan
-            }
-            throw error;
-        }
-
-
-        if (itemStats.isDirectory()) {
-            tree.children.push(await getDirectoryTree(itemPath, contentBaseDir));
-        } else if (itemStats.isFile() && path.extname(item).toLowerCase() === '.md') {
-            const relativePath = path.relative(contentBaseDir, itemPath);
-            tree.children.push({
-                name: item,
-                path: itemPath, // Store the full path
-                relativePath: relativePath, // Store the path relative to contentBaseDir
-                type: 'file'
-            });
-        }
+        children: [],
+      };
     }
-    // Sort children: folders first, then files, then alphabetically
-    tree.children.sort((a, b) => {
-        if (a.type === b.type) {
-            return a.name.localeCompare(b.name);
-        }
-        return a.type === 'folder' ? -1 : 1;
-    });
-    return tree;
+    throw error; // Re-throw other errors
+  }
+
+  if (!stats.isDirectory()) {
+    throw new Error(`Path is not a directory: ${dirPath}`);
+  }
+
+  const items = await fs.readdir(dirPath);
+  const tree = {
+    name: path.basename(dirPath),
+    path: dirPath,
+    type: 'folder',
+    children: [],
+  };
+
+  for (const item of items) {
+    // Ignore .gitkeep or other hidden files if necessary
+    if (item.startsWith('.')) {
+      continue;
+    }
+    const itemPath = path.join(dirPath, item);
+    let itemStats;
+    try {
+      itemStats = await fs.stat(itemPath);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        console.warn(
+          `File/directory not found during scan: ${itemPath}. Skipping.`
+        );
+        continue; // Skip this item if it disappeared during scan
+      }
+      throw error;
+    }
+
+    if (itemStats.isDirectory()) {
+      tree.children.push(await getDirectoryTree(itemPath, contentBaseDir));
+    } else if (
+      itemStats.isFile() &&
+      path.extname(item).toLowerCase() === '.md'
+    ) {
+      const relativePath = path.relative(contentBaseDir, itemPath);
+      tree.children.push({
+        name: item,
+        path: itemPath, // Store the full path
+        relativePath: relativePath, // Store the path relative to contentBaseDir
+        type: 'file',
+      });
+    }
+  }
+  // Sort children: folders first, then files, then alphabetically
+  tree.children.sort((a, b) => {
+    if (a.type === b.type) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.type === 'folder' ? -1 : 1;
+  });
+  return tree;
 }
 
 /**
  * @module services/fileService
  * @description Provides file system utility functions.
  */
-export {
-    getDirectoryTree
-};
+export { getDirectoryTree };

--- a/services/searchService.js
+++ b/services/searchService.js
@@ -17,7 +17,7 @@ let idx;
 /**
  * A map storing document details by their reference ID (relative path).
  * Used to retrieve original document information after a search.
- * @type {Object<string, {id: string, name: string, content: string}>}
+ * @type {object<string, {id: string, name: string, content: string}>}
  */
 let documentMap = {}; // Maps document refs (like relative paths) to their original content/title
 
@@ -32,24 +32,27 @@ let documentMap = {}; // Maps document refs (like relative paths) to their origi
  * Recursively fetches all Markdown file paths from a directory tree structure.
  * @async
  * @function getAllMarkdownFiles
- * @param {module:services/fileService.DirectoryTreeNode} node - The current node in the directory tree.
- * @param {string} [currentPath=''] - The current relative path (used internally for recursion).
+ * @param {module:services/fileService.DirectoryTreeNode} node The current node in the directory tree.
+ * @param {string} [currentPath=''] The current relative path (used internally for recursion).
  * @returns {Promise<MarkdownFileInfo[]>} A promise that resolves to an array of objects,
  *                                       each containing the `path` and `relativePath` of a Markdown file.
  */
 async function getAllMarkdownFiles(node, currentPath = '') {
-    let files = [];
-    if (node.type === 'file' && node.name.endsWith('.md')) {
-        // node.path is already the full path from fileService
-        // node.relativePath is relative to contentDir
-        files.push({ path: node.path, relativePath: node.relativePath || node.name });
+  let files = [];
+  if (node.type === 'file' && node.name.endsWith('.md')) {
+    // node.path is already the full path from fileService
+    // node.relativePath is relative to contentDir
+    files.push({
+      path: node.path,
+      relativePath: node.relativePath || node.name,
+    });
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      files = files.concat(await getAllMarkdownFiles(child));
     }
-    if (node.children) {
-        for (const child of node.children) {
-            files = files.concat(await getAllMarkdownFiles(child));
-        }
-    }
-    return files;
+  }
+  return files;
 }
 
 /**
@@ -64,44 +67,47 @@ async function getAllMarkdownFiles(node, currentPath = '') {
  * Builds the Lunr.js search index from Markdown files found in the directory tree.
  * It reads each Markdown file, creates a document object, and adds it to the index.
  * The `documentMap` is also populated for later retrieval of document details.
- *
  * @async
  * @function buildIndex
- * @param {module:services/fileService.DirectoryTreeNode} directoryTree - The directory tree structure containing Markdown files.
+ * @param {module:services/fileService.DirectoryTreeNode} directoryTree The directory tree structure containing Markdown files.
  * @returns {Promise<void>} A promise that resolves when the index is built.
  */
 async function buildIndex(directoryTree) {
-    console.log("Starting to build search index...");
-    const documents = [];
-    documentMap = {}; // Reset map
+  console.log('Starting to build search index...');
+  const documents = [];
+  documentMap = {}; // Reset map
 
-    const markdownFiles = await getAllMarkdownFiles(directoryTree);
+  const markdownFiles = await getAllMarkdownFiles(directoryTree);
 
-    for (const fileInfo of markdownFiles) {
-        try {
-            const content = await fs.readFile(fileInfo.path, 'utf-8');
-            const doc = {
-                id: fileInfo.relativePath, // Use relative path as unique ID
-                name: path.basename(fileInfo.relativePath, '.md'),
-                content: content
-            };
-            documents.push(doc);
-            documentMap[fileInfo.relativePath] = doc; // Store for easy lookup
-        } catch (error) {
-            console.error(`Error reading file ${fileInfo.path} for indexing:`, error);
-        }
+  for (const fileInfo of markdownFiles) {
+    try {
+      const content = await fs.readFile(fileInfo.path, 'utf-8');
+      const doc = {
+        id: fileInfo.relativePath, // Use relative path as unique ID
+        name: path.basename(fileInfo.relativePath, '.md'),
+        content: content,
+      };
+      documents.push(doc);
+      documentMap[fileInfo.relativePath] = doc; // Store for easy lookup
+    } catch (error) {
+      console.error(`Error reading file ${fileInfo.path} for indexing:`, error);
     }
+  }
 
-    idx = lunr(function () {
-        this.ref('id'); // Document reference, our relativePath
-        this.field('name', { boost: 10 }); // Boost matches in title
-        this.field('content');
+  idx = lunr(function() {
+    // eslint-disable-next-line no-invalid-this
+    this.ref('id'); // Document reference, our relativePath
+    // eslint-disable-next-line no-invalid-this
+    this.field('name', { boost: 10 }); // Boost matches in title
+    // eslint-disable-next-line no-invalid-this
+    this.field('content');
 
-        documents.forEach(function (doc) {
-            this.add(doc);
-        }, this);
-    });
-    console.log(`Search index built. ${documents.length} documents indexed.`);
+    documents.forEach(function(doc) {
+      // eslint-disable-next-line no-invalid-this
+      this.add(doc);
+    }, this);
+  });
+  console.log(`Search index built. ${documents.length} documents indexed.`);
 }
 
 /**
@@ -114,42 +120,42 @@ async function buildIndex(directoryTree) {
 
 /**
  * Searches the built Lunr.js index for a given query.
- *
  * @function search
- * @param {string} query - The search query string.
+ * @param {string} query The search query string.
  * @returns {SearchResult[]} An array of search results, each containing the path, name, and score.
  *                           Returns an empty array if the index is not built or if an error occurs.
  */
 function search(query) {
-    if (!idx) {
-        console.warn("Search index not built yet.");
-        return [];
-    }
-    try {
-        const results = idx.search(query);
-        // Map results back to original document details if needed (e.g., for snippets or full titles)
-        return results.map(result => {
-            const doc = documentMap[result.ref];
-            return {
-                path: result.ref, // This is the relativePath
-                name: doc ? doc.name : result.ref, // Fallback to ref if not in map (shouldn't happen)
-                score: result.score,
-                // To include snippets, Lunr needs extra setup or client-side processing
-                // For now, just returning path and name.
-            };
-        });
-    } catch (error) {
-        // Handle cases where Lunr might throw error on certain query syntax if not robust
-        console.error("Error during search:", error);
-        return [];
-    }
+  if (!idx) {
+    console.warn('Search index not built yet.');
+    return [];
+  }
+  try {
+    const results = idx.search(query);
+    // Map results back to original document details if needed (e.g., for snippets or full titles)
+    return results.map((result) => {
+      const doc = documentMap[result.ref];
+      return {
+        path: result.ref, // This is the relativePath
+        name: doc ? doc.name : result.ref, // Fallback to ref if not in map (shouldn't happen)
+        score: result.score,
+        // To include snippets, Lunr needs extra setup or client-side processing
+        // For now, just returning path and name.
+      };
+    });
+  } catch (error) {
+    // Handle cases where Lunr might throw error on certain query syntax if not robust
+    console.error('Error during search:', error);
+    return [];
+  }
 }
 
 /**
  * @module services/searchService
  * @description Provides functionalities to build a search index and perform searches on documents.
  */
-export { // Changed to ES6 export
-    buildIndex,
-    search
+export {
+  // Changed to ES6 export
+  buildIndex,
+  search,
 };


### PR DESCRIPTION
This is a work-in-progress commit for the task of reformatting the codebase according to Google Style Guides and addressing associated linting issues.

Steps taken so far:

1.  **Initial Request:** Fix header style (search box white block).
    *   Identified CSS issue in `.search-bar` class.
    *   Commented out conflicting CSS properties.

2.  **Second Request:** Remove all commented-out code.
    *   Identified target CSS and JS files.
    *   Removed commented-out CSS from `public/css/style.css`.
    *   Removed commented-out JS code from `public/js/main.js`, `services/searchService.js`, `routes/view.js`, `app.js`, and `server.js`, while preserving JSDoc and explanatory comments.

3.  **Third Request:** Format and document all code (CSS, HTML/EJS, JS) according to Google Coding Standards.
    *   **Research:** Reviewed Google Style Guides for JS, HTML, and CSS.
    *   **Tooling Setup:**
        *   Installed Prettier, ESLint, `eslint-config-google`, `eslint-plugin-jsdoc`, `@eslint/js`, `globals`, `@eslint/eslintrc`.
        *   Created `.prettierrc.json` and `.prettierignore`.
        *   Migrated ESLint config from `.eslintrc.json` to `eslint.config.js` (flat config) to use `eslint-config-google` and `eslint-plugin-jsdoc`.
        *   Added `lint` and `format` scripts to `package.json`.
    *   **JavaScript Processing (In Progress):**
        *   Ran Prettier (`npm run format`) to apply initial formatting.
        *   Iteratively ran ESLint (`npm run lint -- --fix`) and made manual corrections:
            *   Fixed ESLint configuration issues related to flat config, plugin loading (`eslint-plugin-jsdoc`), and rule option compatibility.
            *   Added missing JSDoc comments to functions in `app.js` as per `jsdoc/require-jsdoc`.
            *   Addressed `new-cap` error in `routes/view.js` by disabling the rule for an Express route handler where it was a false positive.
            *   Corrected JSDoc type for `documentMap` in `services/searchService.js` (`Object` to `object`).
            *   Disabled `no-invalid-this` for specific lines in `services/searchService.js` where `this` is used correctly by the Lunr.js library.
            *   Disabled ESLint's `comma-dangle` rule to let Prettier manage it.

**Current Status & Next Steps (Cut Short):**
I was in the middle of processing JavaScript files. The next step was to run `npm run lint` again after the latest batch of fixes and continue iterating on the JS files until all ESLint issues (guided by Google Style) were resolved. After that, I planned to move on to CSS and EJS file formatting and documentation.

This commit captures the progress up to this point.